### PR TITLE
use copysign when making onb

### DIFF
--- a/src/integrators/mega_path.cpp
+++ b/src/integrators/mega_path.cpp
@@ -57,6 +57,7 @@ protected:
         auto swl = spectrum->sample(spectrum->node()->is_fixed() ? 0.f : sampler()->generate_1d());
         SampledSpectrum beta{swl.dimension(), camera_weight};
         SampledSpectrum Li{swl.dimension()};
+        Float eta_scale = def(1.f);
 
         auto ray = camera_ray;
         auto pdf_bsdf = def(1e16f);
@@ -109,7 +110,6 @@ protected:
 
             // evaluate material
             auto surface_tag = it->shape().surface_tag();
-            auto eta_scale = def(1.f);
 
             $outline {
                 PolymorphicCall<Surface::Closure> call;
@@ -137,8 +137,8 @@ protected:
                     // apply eta scale
                     auto eta = closure->eta().value_or(1.f);
                     $switch(surface_sample.event) {
-                        $case(Surface::event_enter) { eta_scale = sqr(eta); };
-                        $case(Surface::event_exit) { eta_scale = sqr(1.f / eta); };
+                        $case(Surface::event_enter) { eta_scale *= sqr(eta); };
+                        $case(Surface::event_exit) { eta_scale *= sqr(1.f / eta); };
                     };
                 });
             };

--- a/src/util/frame.cpp
+++ b/src/util/frame.cpp
@@ -19,7 +19,7 @@ Frame::Frame() noexcept
       _n{make_float3(0.f, 0.f, 1.f)} {}
 
 Frame Frame::make(Expr<float3> n) noexcept {
-    auto sgn = sign(n.z);
+    auto sgn = copysign(1.f, n.z);
     auto a = -1.f / (sgn + n.z);
     auto b = n.x * n.y * a;
     auto s = make_float3(1.f + sgn * sqr(n.x) * a, sgn * b, -sgn * n.x);


### PR DESCRIPTION
- upstream luisacompute commit (12647ff0c96775770c23c705e76cb24e6ba82970) changes defn of `sign`, not merged yet but it causes div by zero

other uses of `sign` look fine to me? they mainly surface when `wo` / `wh` have z = 0, in which case its a grazing ray and has no contribution anyways